### PR TITLE
buffer error logs while permissions are dropped

### DIFF
--- a/osquery/tables/system/linux/deb_packages.cpp
+++ b/osquery/tables/system/linux/deb_packages.cpp
@@ -20,6 +20,19 @@ namespace tables {
 
 namespace {
 
+// Struct to hold an error we wish to buffer and log later.
+// See #8286
+struct ErrorLog {
+  std::string message;
+  Error<IDpkgQuery::ErrorCode> code;
+  std::string admindir;
+
+  ErrorLog(const std::string& msg,
+           Error<IDpkgQuery::ErrorCode>&& c,
+           const std::string& dir)
+      : message(msg), code(std::move(c)), admindir(dir) {}
+};
+
 // From the documentation: this directory contains many files that give
 // information about status of installed or uninstalled packages
 const std::string kAdminDir{"/var/lib/dpkg"};
@@ -42,6 +55,7 @@ void logError(Logger& logger,
 
 QueryData genDebPackagesImpl(QueryContext& context, Logger& logger) {
   std::vector<std::string> admindir_list{};
+  std::vector<ErrorLog> errorLogBuffer{};
 
   if (context.hasConstraint("admindir", EQUALS)) {
     for (const auto& admindir :
@@ -56,59 +70,65 @@ QueryData genDebPackagesImpl(QueryContext& context, Logger& logger) {
   // Drop to 'nobody' to ensure that the libdpkg library
   // can't change the package database. Privileges will be
   // restored automatically when the `dropper` object goes
-  // out of scope.
+  // out of scope.  In the meantime we'll buffer all logs
+  // since the reduced permissions will block creation
+  // of the log file.
   //
   // Note that this is *NOT* a security feature
-  auto dropper = DropPrivileges::get();
-  dropper->dropTo("nobody");
-
   QueryData results;
+  {
+    auto dropper = DropPrivileges::get();
+    dropper->dropTo("nobody");
 
-  for (const auto& admindir : admindir_list) {
-    if (!pathExists(admindir).ok()) {
-      continue;
+    for (const auto& admindir : admindir_list) {
+      if (!pathExists(admindir).ok()) {
+        continue;
+      }
+      auto dpkg_query_exp = IDpkgQuery::create(admindir);
+      if (dpkg_query_exp.isError()) {
+        errorLogBuffer.emplace_back("Failed to open the dpkg database",
+                                    dpkg_query_exp.takeError(),
+                                    admindir);
+
+        continue;
+      }
+
+      auto dpkg_query = dpkg_query_exp.take();
+
+      auto package_list_exp = dpkg_query->getPackageList();
+      if (package_list_exp.isError()) {
+        errorLogBuffer.emplace_back("Failed to list the packages",
+                                    package_list_exp.takeError(),
+                                    admindir);
+
+        continue;
+      }
+
+      auto package_list = package_list_exp.take();
+
+      for (const auto& package : package_list) {
+        Row r;
+        r["name"] = package.name;
+        r["version"] = package.version;
+        r["arch"] = package.arch;
+        r["status"] = package.status;
+        r["revision"] = package.revision;
+        r["priority"] = package.priority;
+        r["section"] = package.section;
+        r["source"] = package.source;
+        r["size"] = package.size;
+        r["maintainer"] = package.maintainer;
+        r["admindir"] = admindir;
+        r["pid_with_namespace"] = "0";
+
+        results.push_back(std::move(r));
+      }
     }
-    auto dpkg_query_exp = IDpkgQuery::create(admindir);
-    if (dpkg_query_exp.isError()) {
-      logError(logger,
-               "Failed to open the dpkg database",
-               dpkg_query_exp.takeError(),
-               admindir);
+  }
 
-      continue;
-    }
-
-    auto dpkg_query = dpkg_query_exp.take();
-
-    auto package_list_exp = dpkg_query->getPackageList();
-    if (package_list_exp.isError()) {
-      logError(logger,
-               "Failed to list the packages",
-               package_list_exp.takeError(),
-               admindir);
-
-      continue;
-    }
-
-    auto package_list = package_list_exp.take();
-
-    for (const auto& package : package_list) {
-      Row r;
-      r["name"] = package.name;
-      r["version"] = package.version;
-      r["arch"] = package.arch;
-      r["status"] = package.status;
-      r["revision"] = package.revision;
-      r["priority"] = package.priority;
-      r["section"] = package.section;
-      r["source"] = package.source;
-      r["size"] = package.size;
-      r["maintainer"] = package.maintainer;
-      r["admindir"] = admindir;
-      r["pid_with_namespace"] = "0";
-
-      results.push_back(std::move(r));
-    }
+  // Now that we have privileges restored, we can log the errors.
+  for (const auto& errorLog : errorLogBuffer) {
+    logError(logger, errorLog.message, errorLog.code, errorLog.admindir);
   }
 
   return results;


### PR DESCRIPTION
For #8286
Fleet: https://github.com/fleetdm/fleet/issues/24877

# Overview

This PR addresses an issue on CentOS and Fedora (and possibly other) distributions where errors are encountered when attempting to log to a file while generating the `deb_packages` table.  This occurs because we drop permissions while generating this table, which means we don't have access to create the logfile.

The solution in this PR as suggested by @lucasmrod is to buffer the logs while permissions are dropped, and output them after perms are restored.  The number of error logs directly produced by this table is limited by the number of admin dirs specified in the query, so the buffer size isn't a big concern there.  

# Testing

To test this I set up a Fedora 41 VM.  Running the main branch of osquery with a scheduled query of the `deb_packages` table, I saw:
<img width="390" alt="image" src="https://github.com/user-attachments/assets/f4bfb4c5-9a34-4d35-9d43-1c7490ddaa3f" />

and no error log file was created.

Running the same on this branch, the console error above did not appear and the log file was created as expected, with the expected logs inside. 
